### PR TITLE
consider WKCompanionAppBundleIdentifier during ipa upload

### DIFF
--- a/server/db/jamf.js
+++ b/server/db/jamf.js
@@ -129,7 +129,7 @@ function postJamfAppIPA(req, res, next) {
         console.log(parseErr);
       }
 
-      if (ipaInfo.CFBundleIdentifier !== req.query.bundle_id) {
+      if (ipaInfo.CFBundleIdentifier !== req.query.bundle_id && ipaInfo.WKCompanionAppBundleIdentifier !== req.query.bundle_id) {
         res.status(400).json({ error: 'The uploaded file bundle ID does not match the Jamf Bundle ID, are you sure the file you are uploading is correct? The file was not uploaded' });
       } else if (req.file !== undefined && req.file.path !== undefined) {
         // File uploaded to temp storage OK, lets push it to Jamf


### PR DESCRIPTION
When uploading a new ipa, the bundle identifier check might fail if it contains a WatchKit App. In this case, it compares the bundle identifier maintained in jamf/asc to the bundle identifier that is found in the first Info.plist found inside the ipa.

I added a condition to the if statement that also checks `WKCompanionAppBundleIdentifier`. The ipa is considered valid in case `CFBundleIdentifier` or `WKCompanionAppBundleIdentifier` is equal to what is maintained in jamf/asc.